### PR TITLE
Fix the AI monologue bug, fix listening for event that won't fire

### DIFF
--- a/src/main/java/cc/reconnected/chatbox/listeners/ChatboxEvents.java
+++ b/src/main/java/cc/reconnected/chatbox/listeners/ChatboxEvents.java
@@ -52,7 +52,10 @@ public class ChatboxEvents {
             SolsticeEvents.register();
         }
 
-        ClientPacketsHandler.register();
+        // Bomber: I would like to have a few words with whoever decided to try listening to the server starting
+        // event INSIDE ClientPacketsHandler's register method... that is only run after the server starting event
+        // has fired...
+        ClientPacketsHandler.register(serverStarting);
         ClientConnectionEvents.CONNECT.register((conn, license, isGuest) -> {
             var playerData = PlayerMeta.getPlayer(license.userId());
 


### PR DESCRIPTION
Fixed the bug where the server would crash if a websocket connection gets closed just after sending a chatbox message.
Also fixed a NullPointerException caused by the fact that we were trying to listen for SERVER_STARTING event in ClientPacketsHandler's register method.... that gets called after said event is fired.