### PR TITLE
Fix chatbox crash...again

### DIFF
--- a/src/main/java/cc/reconnected/chatbox/ClientPacketsHandler.java
+++ b/src/main/java/cc/reconnected/chatbox/ClientPacketsHandler.java
@@ -19,6 +19,7 @@ import net.kyori.adventure.text.serializer.json.JSONComponentSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.minecraft.server.MinecraftServer;
 import org.java_websocket.WebSocket;
+import org.java_websocket.exceptions.WebsocketNotConnectedException;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
@@ -85,8 +86,12 @@ public class ClientPacketsHandler {
                 }
                 Webhook.send(uuid, msg, player);
                 player.sendMessage(msg.message);
-
-                msg.conn.send(RccChatbox.GSON.toJson(new SuccessPacket("message_sent", msg.id)));
+                // Last line of defense ~~against qrmcat/bomber's wonderful software~~
+                try {
+                    msg.conn.send(RccChatbox.GSON.toJson(new SuccessPacket("message_sent", msg.id)));
+                } catch(WebsocketNotConnectedException e) {
+                    RccChatbox.LOGGER.warn("Was unable to send message confirmation to a disconnected websocket (UUID: {})", uuid);
+                }
             }
         }
     }


### PR DESCRIPTION
Apparently just having a check in the top of the ticking wasn't enough, as the websocket connection may close while the message is being processed, leading to a WebsocketNotConnectedException crashing the minecraft server.
This PR fixes this by handling said exception gracefully, just printing a warning message about it